### PR TITLE
Fix sometimes diggers dont equip

### DIFF
--- a/NGUInjector/AllocationProfiles/Breakpoints/DiggerBreakpoints.cs
+++ b/NGUInjector/AllocationProfiles/Breakpoints/DiggerBreakpoints.cs
@@ -21,7 +21,7 @@ namespace NGUInjector.AllocationProfiles.Breakpoints
             {
                 Main.Log($"Equipping Diggers: {string.Join(", ", bp.priorities)}");
                 current = bp;
-                return true;
+                return false;
             }
             else
             {


### PR DESCRIPTION
Sometimes diggers did not equip after rebirth, and it erase hours of progress.
This is a easy fix, just let diggers re-equip every loop like energy/magic